### PR TITLE
fix: hardcode v4.2 --no-xdp (drop unreliable probes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,20 +239,14 @@ sudo bash system-optimize.sh
 sudo bash update-runtime.sh --restart
 ```
 
-> **v4.2 note**: Agave/Jito v4.2+ enables XDP by default and requires
-> `--no-xdp` together with `--allow-private-addr`. It also renamed
-> `--accounts-db-cache-limit-mb` to `--accounts-db-write-cache-limit` and removed
-> `--accounts-db-access-storages-method`. The launcher probes the installed
-> binary and applies the correct flags automatically, but only after the runtime
-> scripts are synced — otherwise the node crash-loops. Always run
-> `update-runtime.sh` above after an upgrade.
->
-> **v4.3 (upcoming)**: `--limit-ledger-size` will be deprecated in favor of
-> `--limit-blockstore-size`. The launcher keeps the current flag for v4.2 and
-> will switch when v4.3 lands.
+> **v4.2 note**: Runtime scripts support Agave/Jito **v4.2+ only**. v4.2 enables
+> XDP by default and requires `--no-xdp` with `--allow-private-addr`; the
+> accounts cache flag is `--accounts-db-write-cache-limit`. After upgrading the
+> binary without syncing runtime scripts, the node crash-loops — always run
+> `update-runtime.sh` above. v4.1.x launch flags are no longer supported.
 
-If the node runs `v4.1.x-jito` or an older release, build the tested release
-first. The final restart briefly interrupts RPC service:
+If the node runs `v4.1.x-jito` or an older release, build v4.2.1 first. The
+final restart briefly interrupts RPC service:
 
 ```bash
 # Press Enter at the version prompt to select v4.2.1.

--- a/README_CN.md
+++ b/README_CN.md
@@ -227,17 +227,13 @@ sudo bash system-optimize.sh
 sudo bash update-runtime.sh --restart
 ```
 
-> **v4.2 注意**：Agave/Jito v4.2+ 默认启用 XDP，且 `--allow-private-addr` 必须
-> 搭配 `--no-xdp`；同时把 `--accounts-db-cache-limit-mb` 改名为
-> `--accounts-db-write-cache-limit`，并移除了 `--accounts-db-access-storages-method`。
-> 启动脚本会探测已安装二进制并自动使用正确参数，但前提是运行脚本已同步 —— 否则
-> 节点会 crash-loop。升级后请务必执行上面的 `update-runtime.sh`。
->
-> **v4.3（即将到来）**：`--limit-ledger-size` 将被 `--limit-blockstore-size` 取代。
-> 启动脚本在 v4.2 下仍使用当前参数，待 v4.3 落地后再切换。
+> **v4.2 注意**：本仓库运行脚本仅支持 Agave/Jito **v4.2+**。v4.2 默认启用 XDP，
+> 且 `--allow-private-addr` 必须搭配 `--no-xdp`；账户缓存参数改为
+> `--accounts-db-write-cache-limit`。升级二进制后若未同步运行脚本，节点会
+> crash-loop —— 请务必执行上面的 `update-runtime.sh`。不再兼容 v4.1.x 启动参数。
 
-如果仍是 `v4.1.x-jito` 或更早版本，先编译已验证版本。最后一次重启会短暂中断
-RPC 服务：
+如果仍是 `v4.1.x-jito` 或更早版本，先编译 v4.2.1。最后一次重启会短暂中断 RPC
+服务：
 
 ```bash
 # 版本提示处直接回车选择 v4.2.1。

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -70,9 +70,12 @@ if [[ -z "$VALIDATOR_CMD" ]]; then
 fi
 
 validator_help=$("$VALIDATOR_CMD" --help 2>&1 || true)
+# Runtime scripts target Agave/Jito v4.2+ only. Fail fast on older binaries.
 required_validator_flags=(
+  --no-xdp
   --no-snapshots
   --accounts-index-limit
+  --accounts-db-write-cache-limit
   --accounts-index-scan-results-limit-mb
   --accounts-shrink-ratio
   --accounts-index-bins
@@ -80,23 +83,10 @@ required_validator_flags=(
 for flag in "${required_validator_flags[@]}"; do
   if ! grep -q -- "$flag" <<<"$validator_help"; then
     echo "[ERROR] Installed validator does not support $flag: $VALIDATOR_CMD" >&2
+    echo "        Rebuild with Jito Solana v4.2.1 or newer, then re-run this script." >&2
     exit 1
   fi
 done
-
-# Agave/Jito v4.2 renamed/removed several flags our launcher probes for at
-# runtime. Warn when the installed binary predates v4.2 so an operator knows a
-# rebuild is required before relying on the new behavior.
-missing_v42=()
-grep -q -- '--no-xdp' <<<"$validator_help" || missing_v42+=(--no-xdp)
-grep -q -- '--accounts-db-write-cache-limit' <<<"$validator_help" \
-  || missing_v42+=(--accounts-db-write-cache-limit)
-if ((${#missing_v42[@]} > 0)); then
-  echo "[WARN] Installed validator does not advertise: ${missing_v42[*]}"
-  echo "       These are Agave/Jito v4.2+ flags. The launcher falls back for"
-  echo "       pre-v4.2 binaries, but a v4.2+ node needs them to start."
-  echo "       If startup fails after upgrade, rebuild with v4.2.1 or newer."
-fi
 
 missing_packages=()
 command -v iostat >/dev/null 2>&1 || missing_packages+=(sysstat)

--- a/validator.sh
+++ b/validator.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Shared Solana RPC launcher. The profile only changes bounded concurrency and
 # accounts-index sharding; all safety-sensitive flags live in one place.
+# Targets Agave/Jito v4.2+ only (default install: v4.2.1).
 
 TOTAL_MEM_GB=$(awk '/MemTotal/ {printf "%.0f", $2/1024/1024}' /proc/meminfo)
 PROFILE=${1:-auto}
@@ -127,23 +128,6 @@ else
   exit 1
 fi
 
-# Probe the installed binary once so renamed/removed flags are applied
-# conditionally without breaking older releases (v4.1.x and earlier).
-VALIDATOR_HELP=$("$VALIDATOR_CMD" --help 2>&1 || true)
-VALIDATOR_VERSION=$("$VALIDATOR_CMD" --version 2>&1 || true)
-has_flag() {
-  grep -q -- "$1" <<<"$VALIDATOR_HELP"
-}
-
-# Parse "major.minor" out of e.g. "agave-validator 4.2.1 (src:...)" so the
-# launcher can fall back to a version check when --help hides a flag.
-VALIDATOR_MAJOR=0
-VALIDATOR_MINOR=0
-if [[ "$VALIDATOR_VERSION" =~ (^|[^0-9])([0-9]+)\.([0-9]+) ]]; then
-  VALIDATOR_MAJOR=${BASH_REMATCH[2]}
-  VALIDATOR_MINOR=${BASH_REMATCH[3]}
-fi
-
 ARGS=(
   --ledger /root/sol/ledger
   --accounts /root/sol/accounts
@@ -163,6 +147,7 @@ ARGS=(
   --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
   --only-known-rpc
   --no-port-check
+  --no-xdp
   --dynamic-port-range "$DYNAMIC_PORT_RANGE"
   --gossip-port "$GOSSIP_PORT"
   --rpc-bind-address 0.0.0.0
@@ -180,6 +165,7 @@ ARGS=(
   --limit-ledger-size 50000000
   --wal-recovery-mode skip_any_corrupted_record
   --accounts-index-limit minimal
+  --accounts-db-write-cache-limit "${ACCOUNTS_CACHE_MB}MB"
   --accounts-index-scan-results-limit-mb 256
   --accounts-shrink-ratio 0.80
   --accounts-index-bins "$ACCOUNTS_INDEX_BINS"
@@ -188,38 +174,6 @@ ARGS=(
   --allow-private-addr
   --bind-address 0.0.0.0
 )
-
-# Agave v4.2+ enables XDP by default. Gossip egress with --allow-private-addr
-# requires --no-xdp; without it the validator exits immediately on startup.
-# Probe so older binaries that lack the flag (e.g. v4.1.x) still work, and fall
-# back to a version check in case --help does not advertise the flag.
-NO_XDP=0
-if has_flag --no-xdp; then
-  ARGS+=(--no-xdp)
-  NO_XDP=1
-elif (( VALIDATOR_MAJOR > 4 || (VALIDATOR_MAJOR == 4 && VALIDATOR_MINOR >= 2) )); then
-  ARGS+=(--no-xdp)
-  NO_XDP=1
-fi
-
-# The accounts-db write cache flag was renamed in v4.2:
-#   --accounts-db-cache-limit-mb (integer MB) -> --accounts-db-write-cache-limit
-#   (byte size accepting SI/IEC prefixes). The old flag was removed, so fall
-#   back to it only on pre-v4.2 binaries.
-ACCOUNTS_CACHE_FLAG=""
-if has_flag --accounts-db-write-cache-limit; then
-  ARGS+=(--accounts-db-write-cache-limit "${ACCOUNTS_CACHE_MB}MB")
-  ACCOUNTS_CACHE_FLAG="--accounts-db-write-cache-limit ${ACCOUNTS_CACHE_MB}MB"
-elif has_flag --accounts-db-cache-limit-mb; then
-  ARGS+=(--accounts-db-cache-limit-mb "$ACCOUNTS_CACHE_MB")
-  ACCOUNTS_CACHE_FLAG="--accounts-db-cache-limit-mb ${ACCOUNTS_CACHE_MB}"
-fi
-
-# --accounts-db-access-storages-method was removed in v4.2 (file I/O is now the
-# only access method). Keep passing "file" only where the flag still exists.
-if has_flag --accounts-db-access-storages-method; then
-  ARGS+=(--accounts-db-access-storages-method file)
-fi
 
 if [[ "$ENABLE_GEYSER" == "1" ]]; then
   ARGS+=(--geyser-plugin-config "$GEYSER_CONFIG_PATH")
@@ -241,11 +195,11 @@ echo "Solana RPC profile: $PROFILE_LABEL"
 echo "System RAM: ${TOTAL_MEM_GB}GB"
 echo "RPC threads: $RPC_THREADS | Accounts cache: ${ACCOUNTS_CACHE_MB}MB | Index bins: $ACCOUNTS_INDEX_BINS"
 echo "Accounts shrink ratio: 0.80 | Disk-backed index: minimal"
-echo "Geyser: $ENABLE_GEYSER | ALT index: $ENABLE_ALT_INDEX | TX history: $ENABLE_TX_HISTORY | no-xdp: $NO_XDP | accounts-cache: ${ACCOUNTS_CACHE_FLAG:-none}"
+echo "Geyser: $ENABLE_GEYSER | ALT index: $ENABLE_ALT_INDEX | TX history: $ENABLE_TX_HISTORY"
 if [[ "$ENABLE_GEYSER" == "1" ]]; then
   echo "Geyser config: $GEYSER_CONFIG_PATH"
 fi
-echo "Validator: $VALIDATOR_CMD (${VALIDATOR_VERSION})"
+echo "Validator: $VALIDATOR_CMD"
 echo "=================================================================="
 
 exec "$VALIDATOR_CMD" "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- DeepSeek 版用 `--help` / `--version` 探测 `--no-xdp`，在真实 v4.2.1 节点上仍可能漏加，导致 `sol.service` crash-loop；社区实测直接硬编码即可启动。
- 去掉全部 flag 探测与旧版 fallback，启动参数固定为 Agave/Jito **v4.2+**：`--no-xdp`、`--accounts-db-write-cache-limit`，不再传已移除的 `--accounts-db-access-storages-method`。
- `update-runtime.sh` 对缺少 v4.2 必需参数的二进制直接报错退出，避免“看起来更新成功、实际起不来”。

## Test plan
- [ ] 在已编译 `v4.2.1-jito` 的机器上：`git pull` 本分支后执行 `sudo bash update-runtime.sh --restart`
- [ ] `systemctl status sol` 应为 active，不再 auto-restart
- [ ] `journalctl -u sol -n 50` / 启动横幅确认进程未因 unknown argument 退出
- [ ] 确认 `agave-validator` 命令行包含 `--no-xdp` 与 `--accounts-db-write-cache-limit`
- [ ] （预期失败）若仍是 v4.1.x，`update-runtime.sh` 应明确报缺少 `--no-xdp` / `--accounts-db-write-cache-limit`


Made with [Cursor](https://cursor.com)