### PR TITLE
fix: keep conservative RPC knobs on high-RAM hosts

### DIFF
--- a/2-install-jito-validator.sh
+++ b/2-install-jito-validator.sh
@@ -150,7 +150,7 @@ if [[ "$LANG_SCRIPT" == "zh" ]]; then
   M_STEP8="生成 Validator Keypair..."
   M_STEP9="配置防火墙..."
   M_STEP10="复制 validator 配置文件..."
-  M_TIER="检测到 %sGB RAM - 将使用 TIER %s 配置"
+  M_TIER="检测到 %sGB RAM - 使用 %s 标签，RPC 参数与 128GB 保守配置相同"
   M_STEP11="配置 systemd 服务..."
   M_SVC_UPDATED="systemd 服务配置已更新"
   M_STEP12="下载 Yellowstone gRPC geyser..."
@@ -206,7 +206,7 @@ else
   M_STEP8="Generate Validator Keypair..."
   M_STEP9="Configure firewall..."
   M_STEP10="Copy validator configs..."
-  M_TIER="%sGB RAM detected - using TIER %s config"
+  M_TIER="%sGB RAM detected - using %s label with the same conservative 128GB RPC knobs"
   M_STEP11="Configure systemd service..."
   M_SVC_UPDATED="systemd service updated"
   M_STEP12="Download Yellowstone gRPC geyser..."
@@ -441,13 +441,13 @@ chmod +x "$BIN"/validator*.sh "$BIN/select-validator.sh"
 
 TOTAL_MEM_GB=$(awk '/MemTotal/ {printf "%.0f", $2/1024/1024}' /proc/meminfo)
 if [[ $TOTAL_MEM_GB -lt 160 ]]; then
-  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "1 (128GB)"
+  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "128g"
 elif [[ $TOTAL_MEM_GB -lt 224 ]]; then
-  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "2 (192GB)"
+  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "192g"
 elif [[ $TOTAL_MEM_GB -lt 384 ]]; then
-  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "3 (256GB)"
+  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "256g"
 else
-  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "4 (512GB+)"
+  printf "   ✓ $M_TIER\n" "$TOTAL_MEM_GB" "512g"
 fi
 
 echo ""

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It is built for operators who need a practical Solana mainnet RPC deployment gui
 | `1-prepare.sh` | Mount NVMe data disks, create Solana directories, and apply Linux system optimizations |
 | `2-install-jito-validator.sh` | Build and install Jito Solana / Agave validator from source |
 | `3-start.sh` | Reuse or download a snapshot, install systemd, and start the RPC node without deleting data by default |
-| `validator.sh` | Auto-select the right validator profile for 128GB, 192GB, 256GB, or 512GB+ RAM |
+| `validator.sh` | Auto-select a RAM label; RPC/index/Geyser knobs stay on the conservative 128GB set |
 | `yellowstone-config.json` | Base Yellowstone gRPC Geyser configuration |
 | `performance-monitor.sh`, `get_health.sh`, `catchup.sh` | Monitor node health, memory, performance, and sync progress |
 | `update-runtime.sh` | Apply runtime and monitoring fixes without deleting node data |
@@ -70,10 +70,9 @@ It is built for operators who need a practical Solana mainnet RPC deployment gui
   - **4+ disks**: System + 3 data disks (accounts/ledger/snapshot separated)
 - **OS**: Ubuntu 22.04/24.04
 
-> **128GB/192GB scope:** These are constrained RPC profiles using a disk-backed
-> accounts index and indexing only the Address Lookup Table program. They are not
-> suitable for enabling every account index; Agave recommends substantially more
-> memory for that workload.
+> **RPC scope:** All RAM sizes use a disk-backed accounts index and index only
+> the Address Lookup Table program. They are not suitable for enabling every
+> account index; Agave recommends substantially more memory for that workload.
 - **Network**: High-bandwidth connection (1 Gbps+)
 
 ## 🚀 Quick Start
@@ -284,7 +283,7 @@ The defaults prioritize 128GB/192GB stability, upstream compatibility, and diagn
 ### ⚡ Yellowstone gRPC Configuration
 
 - ✅ **Compression Available**: Clients can negotiate gzip or zstd when bandwidth savings justify CPU cost
-- 📦 **Profile Buffers**: 50K channel/128 unary on 128GB; 100K/256 on 192GB
+- 📦 **Geyser buffers**: 50K channel / 128 unary on every host
 - 🎯 **Upstream Defaults**: System-managed Tokio and default HTTP/2 settings
 - 🛡️ **Resource Protection**: Bounded filter/request counts; authentication remains optional
 
@@ -302,11 +301,10 @@ fully compatible.
   - ⚡ Native CPU instructions and Jito's release-with-LTO build profile
   - ✅ Complete validator binary with full MEV support
   - 🎯 Built from a verified Jito release tag and recorded source commit
-- 🧠 **Intelligent Configuration Selection**: Auto-detects system RAM and selects optimal validator configuration
-  - TIER 1 (128GB): Conservative settings for 128-159GB systems
-  - TIER 2 (192GB): Balanced configuration for 192-223GB systems
-  - TIER 3 (256GB): High-performance for 256-383GB systems
-  - TIER 4 (512GB+): Maximum capacity for enterprise deployments
+- 🧠 **RAM labels only**: Detects system RAM for logging, but keeps the same
+  conservative RPC threads, accounts-index bins, and Geyser concurrency on
+  128GB through 512GB+ hosts. Scaling those knobs with RAM made account reads
+  stall on larger machines.
 - 🔄 **Automatic Disk Management**: Smart disk detection and mounting
 - 🛡️ **Production Ready**: Systemd service with a 90% last-resort host memory safeguard and OOM diagnostics
 - 🌐 **Network Resilience**: Enhanced version verification with graceful degradation
@@ -368,7 +366,7 @@ enabled automatically.
 ├─────────────────────────────────────────────────────────┤
 │  Yellowstone gRPC (Open-Source Tested Config)           │
 │  ├─ Compression: gzip+zstd enabled (fast processing)    │
-│  ├─ Buffers: 50K/128 (128GB), 100K/256 (192GB)         │
+│  ├─ Buffers: 50K/128 on all RAM sizes                   │
 │  ├─ Defaults: System-managed, no over-optimization      │
 │  └─ Protection: Filter and request limits               │
 ├─────────────────────────────────────────────────────────┤
@@ -387,8 +385,8 @@ enabled automatically.
    - gzip and zstd can reduce network bandwidth.
    - Compression consumes CPU, so clients should benchmark it for their traffic.
 
-2. **Queues are bounded per profile**
-   - 128GB nodes use a 50K per-connection channel; 192GB nodes use 100K.
+2. **Queues stay bounded**
+   - Every host uses a 50K per-connection channel and 128 unary limit.
    - A slow consumer may lag or reconnect instead of consuming unbounded node memory.
 
 3. **Leave unrelated runtime controls at upstream defaults**

--- a/README_CN.md
+++ b/README_CN.md
@@ -52,7 +52,7 @@
 | `1-prepare.sh` | 挂载 NVMe 数据盘、创建 Solana 目录并应用 Linux 系统优化 |
 | `2-install-jito-validator.sh` | 从源码构建并安装 Jito Solana / Agave validator |
 | `3-start.sh` | 复用或下载快照、安装 systemd 服务并启动 RPC 节点；默认不删除数据 |
-| `validator.sh` | 根据 128GB、192GB、256GB、512GB+ 内存自动选择 validator 配置 |
+| `validator.sh` | 按内存打标签；RPC/索引/Geyser 参数统一使用 128GB 保守配置 |
 | `yellowstone-config.json` | Yellowstone gRPC Geyser 基础配置 |
 | `performance-monitor.sh`, `get_health.sh`, `catchup.sh` | 查看节点健康状态、内存、性能和同步进度 |
 | `update-runtime.sh` | 不删除节点数据，更新运行参数和监控脚本 |
@@ -70,7 +70,7 @@
   - **4+块盘**: 系统盘 + 3块数据盘 (accounts/ledger/snapshot 完全隔离)
 - **系统**: Ubuntu 22.04/24.04
 
-> **128GB/192GB 适用范围：** 这两档是使用磁盘后备 accounts index 的受限 RPC 配置，仅为 Address Lookup Table 程序建立索引，不适合开启全部账户索引；全量账户索引需要明显更大的内存。
+> **RPC 适用范围：** 所有内存规格都使用磁盘后备 accounts index，且仅为 Address Lookup Table 程序建立索引，不适合开启全部账户索引；全量账户索引需要明显更大的内存。
 - **网络**: 高带宽连接 (1 Gbps+)
 
 ## 🚀 快速开始
@@ -270,7 +270,7 @@ sudo bash update-runtime.sh --restart
 ### ⚡ Yellowstone gRPC 配置
 
 - ✅ **可选压缩**: 客户端可协商 gzip/zstd，以 CPU 换取带宽
-- 📦 **分档队列**: 128GB 使用 50K channel/128 unary；192GB 使用 100K/256
+- 📦 **Geyser 队列**: 所有主机使用 50K channel / 128 unary
 - 🎯 **上游默认**: Tokio 和 HTTP/2 参数保持默认
 - 🛡️ **资源保护**: 限制过滤器和请求数量；鉴权仍为可选项
 
@@ -286,11 +286,9 @@ sudo bash update-runtime.sh --restart
   - ⚡ 使用同机原生 CPU 指令和 Jito release-with-LTO profile
   - ✅ 完整的 validator 二进制文件和完整 MEV 支持
   - 🎯 验证 Jito release tag 并记录源码 commit
-- 🧠 **智能配置选择**: 自动检测系统 RAM 并选择最优 validator 配置
-  - TIER 1 (128GB): 保守配置，适用于 128-159GB 系统
-  - TIER 2 (192GB): 平衡配置，适用于 192-223GB 系统
-  - TIER 3 (256GB): 高性能配置，适用于 256-383GB 系统
-  - TIER 4 (512GB+): 最大容量配置，适用于企业级部署
+- 🧠 **仅作内存标签**: 自动检测系统 RAM 用于日志，但 128GB 到 512GB+ 都使用同一套
+  保守的 RPC 线程、accounts-index bins 和 Geyser 并发。按内存放大这些参数会让
+  大内存机器上的账户读取卡住。
 - 🔄 **自动磁盘管理**: 智能磁盘检测和挂载
 - 🛡️ **生产就绪**: Systemd 服务，90% 主机内存最后保护和 OOM 诊断
 - 🌐 **网络容错**: 增强版本验证，优雅处理网络问题
@@ -348,7 +346,7 @@ IP 白名单配置简单，但客户端公网 IP 变化后必须同步修改。T
 ├─────────────────────────────────────────────────────────┤
 │  Yellowstone gRPC (开源测试配置)                         │
 │  ├─ 压缩: 客户端可协商 gzip+zstd                         │
-│  ├─ 队列: 128GB 50K/128, 192GB 100K/256                │
+│  ├─ 队列: 所有内存规格 50K/128                           │
 │  ├─ 默认值: 系统管理, 无过度优化                         │
 │  └─ 保护: 过滤器和请求限制                               │
 ├─────────────────────────────────────────────────────────┤
@@ -367,8 +365,8 @@ IP 白名单配置简单，但客户端公网 IP 变化后必须同步修改。T
    - gzip/zstd 可以减少网络带宽，但会消耗 CPU。
    - 应根据实际客户端流量测试，而不是默认认为一定降低延迟。
 
-2. **队列按内存分档并设置上限**
-   - 128GB 节点每连接使用 50K channel，192GB 使用 100K。
+2. **队列设置上限，不再按内存放大**
+   - 所有主机每连接使用 50K channel 和 128 unary。
    - 慢客户端可能落后或重连，避免无限消耗节点内存。
 
 3. **无关运行参数保持上游默认**

--- a/validator.sh
+++ b/validator.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Shared Solana RPC launcher. The profile only changes bounded concurrency and
-# accounts-index sharding; all safety-sensitive flags live in one place.
+# Shared Solana RPC launcher. RAM profiles are labels only; RPC threads,
+# accounts-index bins, and Geyser concurrency stay on the 128GB-stable set.
+# Scaling those knobs with RAM made getAccountInfo stall on 256GB/512GB hosts.
 # Targets Agave/Jito v4.2+ only (default install: v4.2.1).
 
 TOTAL_MEM_GB=$(awk '/MemTotal/ {printf "%.0f", $2/1024/1024}' /proc/meminfo)
@@ -20,26 +21,26 @@ if [[ "$PROFILE" == "auto" ]]; then
   fi
 fi
 
+# Keep the proven 128GB RPC/index/Geyser knobs on every host. Higher RAM does
+# not need more bins or unary concurrency; those settings increase lock and
+# disk contention on account reads.
+RPC_THREADS=8
+ACCOUNTS_INDEX_BINS=2048
+GEYSER_CHANNEL_CAPACITY="50_000"
+GEYSER_UNARY_LIMIT=128
+
 case "$PROFILE" in
   128g)
-    RPC_THREADS=8
-    ACCOUNTS_INDEX_BINS=2048
-    PROFILE_LABEL="128GB stability"
+    PROFILE_LABEL="128GB conservative"
     ;;
   192g)
-    RPC_THREADS=10
-    ACCOUNTS_INDEX_BINS=4096
-    PROFILE_LABEL="192GB balanced"
+    PROFILE_LABEL="192GB conservative"
     ;;
   256g)
-    RPC_THREADS=16
-    ACCOUNTS_INDEX_BINS=8192
-    PROFILE_LABEL="256GB performance"
+    PROFILE_LABEL="256GB conservative"
     ;;
   512g)
-    RPC_THREADS=20
-    ACCOUNTS_INDEX_BINS=16384
-    PROFILE_LABEL="512GB performance"
+    PROFILE_LABEL="512GB conservative"
     ;;
   *)
     echo "[ERROR] Unknown profile: $PROFILE (expected 128g, 192g, 256g, or 512g)" >&2
@@ -79,21 +80,6 @@ if [[ "$ENABLE_GEYSER" == "1" ]]; then
       echo "[ERROR] Yellowstone config was not found: $GEYSER_CONFIG_SOURCE" >&2
       exit 1
     fi
-
-    case "$PROFILE" in
-      128g)
-        GEYSER_CHANNEL_CAPACITY="50_000"
-        GEYSER_UNARY_LIMIT=128
-        ;;
-      192g)
-        GEYSER_CHANNEL_CAPACITY="100_000"
-        GEYSER_UNARY_LIMIT=256
-        ;;
-      *)
-        GEYSER_CHANNEL_CAPACITY="200_000"
-        GEYSER_UNARY_LIMIT=1000
-        ;;
-    esac
 
     if ! command -v jq >/dev/null 2>&1; then
       echo "[ERROR] jq is required to generate the profile-specific Yellowstone config" >&2


### PR DESCRIPTION
## Summary
- High-RAM hosts auto-selected the 256GB/512GB profiles, which raised `--rpc-threads`, `--accounts-index-bins`, and Geyser unary concurrency.
- Those extra knobs made `getAccountInfo` stall on large machines while 128GB nodes (8 threads, 2048 bins, 50K/128 Geyser) stayed healthy.
- Keep RAM profiles as labels only. Every host now uses the proven 128GB RPC/index/Geyser set.

## Test plan
- [ ] On a ~377GB host: `git pull` then `sudo bash update-runtime.sh --restart`
- [ ] Confirm startup banner shows 8 RPC threads and 2048 index bins
- [ ] `getBalance` and `getAccountInfo` both return within a few seconds
- [ ] Node remains caught up (`getHealth` / catchup) after the restart


Made with [Cursor](https://cursor.com)