### PR TITLE
fix: replace accounts-index-limit minimal for Agave 4.2 RPC reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ It is built for operators who need a practical Solana mainnet RPC deployment gui
   - **4+ disks**: System + 3 data disks (accounts/ledger/snapshot separated)
 - **OS**: Ubuntu 22.04/24.04
 
-> **128GB/192GB scope:** These are constrained RPC profiles using a disk-backed
-> accounts index and indexing only the Address Lookup Table program. They are not
-> suitable for enabling every account index; Agave recommends substantially more
-> memory for that workload.
+> **RPC scope:** All profiles use a bounded in-memory accounts index (25GB on
+> 128GB hosts, scaling up to unlimited on 512GB+) and index only the Address
+> Lookup Table program. They are not suitable for enabling every account index.
 - **Network**: High-bandwidth connection (1 Gbps+)
 
 ## 🚀 Quick Start
@@ -240,8 +239,10 @@ sudo bash update-runtime.sh --restart
 ```
 
 > **v4.2 note**: Runtime scripts support Agave/Jito **v4.2+ only**. v4.2 enables
-> XDP by default and requires `--no-xdp` with `--allow-private-addr`; the
-> accounts cache flag is `--accounts-db-write-cache-limit`. After upgrading the
+> XDP by default and requires `--no-xdp` with `--allow-private-addr`. The
+> deprecated `--accounts-index-limit minimal` path is not used: 128GB uses
+> `25GB`, 192GB `50GB`, 256GB `100GB`, and 512GB+ `unlimited`, so
+> `getAccountInfo` can be served from RAM after catchup. After upgrading the
 > binary without syncing runtime scripts, the node crash-loops — always run
 > `update-runtime.sh` above. v4.1.x launch flags are no longer supported.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -70,7 +70,9 @@
   - **4+块盘**: 系统盘 + 3块数据盘 (accounts/ledger/snapshot 完全隔离)
 - **系统**: Ubuntu 22.04/24.04
 
-> **128GB/192GB 适用范围：** 这两档是使用磁盘后备 accounts index 的受限 RPC 配置，仅为 Address Lookup Table 程序建立索引，不适合开启全部账户索引；全量账户索引需要明显更大的内存。
+> **RPC 适用范围：** 所有档位都使用有上限的内存 accounts index（128GB 为 25GB，
+> 随内存升高，512GB+ 为 unlimited），且仅为 Address Lookup Table 程序建立索引，
+> 不适合开启全部账户索引。
 - **网络**: 高带宽连接 (1 Gbps+)
 
 ## 🚀 快速开始
@@ -228,9 +230,11 @@ sudo bash update-runtime.sh --restart
 ```
 
 > **v4.2 注意**：本仓库运行脚本仅支持 Agave/Jito **v4.2+**。v4.2 默认启用 XDP，
-> 且 `--allow-private-addr` 必须搭配 `--no-xdp`；账户缓存参数改为
-> `--accounts-db-write-cache-limit`。升级二进制后若未同步运行脚本，节点会
-> crash-loop —— 请务必执行上面的 `update-runtime.sh`。不再兼容 v4.1.x 启动参数。
+> 且 `--allow-private-addr` 必须搭配 `--no-xdp`。不再使用已弃用的
+> `--accounts-index-limit minimal`：128GB 用 `25GB`，192GB 用 `50GB`，256GB 用
+> `100GB`，512GB+ 用 `unlimited`，避免追平后 `getAccountInfo` 卡住。升级二进制后
+> 若未同步运行脚本，节点会 crash-loop —— 请务必执行上面的 `update-runtime.sh`。
+> 不再兼容 v4.1.x 启动参数。
 
 如果仍是 `v4.1.x-jito` 或更早版本，先编译 v4.2.1。最后一次重启会短暂中断 RPC
 服务：

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -75,6 +75,7 @@ required_validator_flags=(
   --no-xdp
   --no-snapshots
   --accounts-index-limit
+  --accounts-db-scan-filter-for-shrinking
   --accounts-db-write-cache-limit
   --accounts-index-scan-results-limit-mb
   --accounts-shrink-ratio

--- a/validator.sh
+++ b/validator.sh
@@ -24,21 +24,25 @@ case "$PROFILE" in
   128g)
     RPC_THREADS=8
     ACCOUNTS_INDEX_BINS=2048
+    ACCOUNTS_INDEX_LIMIT=25GB
     PROFILE_LABEL="128GB stability"
     ;;
   192g)
     RPC_THREADS=10
     ACCOUNTS_INDEX_BINS=4096
+    ACCOUNTS_INDEX_LIMIT=50GB
     PROFILE_LABEL="192GB balanced"
     ;;
   256g)
     RPC_THREADS=16
     ACCOUNTS_INDEX_BINS=8192
+    ACCOUNTS_INDEX_LIMIT=100GB
     PROFILE_LABEL="256GB performance"
     ;;
   512g)
     RPC_THREADS=20
     ACCOUNTS_INDEX_BINS=16384
+    ACCOUNTS_INDEX_LIMIT=unlimited
     PROFILE_LABEL="512GB performance"
     ;;
   *)
@@ -164,7 +168,8 @@ ARGS=(
   --use-snapshot-archives-at-startup when-newest
   --limit-ledger-size 50000000
   --wal-recovery-mode skip_any_corrupted_record
-  --accounts-index-limit minimal
+  --accounts-index-limit "$ACCOUNTS_INDEX_LIMIT"
+  --accounts-db-scan-filter-for-shrinking only-abnormal
   --accounts-db-write-cache-limit "${ACCOUNTS_CACHE_MB}MB"
   --accounts-index-scan-results-limit-mb 256
   --accounts-shrink-ratio 0.80
@@ -194,7 +199,7 @@ echo "=================================================================="
 echo "Solana RPC profile: $PROFILE_LABEL"
 echo "System RAM: ${TOTAL_MEM_GB}GB"
 echo "RPC threads: $RPC_THREADS | Accounts cache: ${ACCOUNTS_CACHE_MB}MB | Index bins: $ACCOUNTS_INDEX_BINS"
-echo "Accounts shrink ratio: 0.80 | Disk-backed index: minimal"
+echo "Accounts shrink ratio: 0.80 | Accounts index limit: $ACCOUNTS_INDEX_LIMIT"
 echo "Geyser: $ENABLE_GEYSER | ALT index: $ENABLE_ALT_INDEX | TX history: $ENABLE_TX_HISTORY"
 if [[ "$ENABLE_GEYSER" == "1" ]]; then
   echo "Geyser config: $GEYSER_CONFIG_PATH"


### PR DESCRIPTION
## Summary
- `getAccountInfo` stalled after catchup on both 128GB and high-RAM hosts, while `getBalance` and slot processing stayed healthy.
- Agave 4.2 deprecates `--accounts-index-limit minimal`, which keeps almost none of the index in RAM; after the write cache flushes, account data loads block on disk.
- Use explicit 4.2 limits on every profile: 128GB `25GB`, 192GB `50GB`, 256GB `100GB`, 512GB+ `unlimited`.
- Pass `--accounts-db-scan-filter-for-shrinking only-abnormal` so post-catchup shrink does not scan the on-disk index.

## Test plan
- [ ] 128GB and ~384GB nodes: `git pull && sudo bash update-runtime.sh --restart`
- [ ] Startup banner shows the new index limit (25GB on 128GB, unlimited on 384GB+)
- [ ] After catchup, both `getBalance` and `getAccountInfo` return
- [ ] Node stays caught up (`getHealth` / catchup)


Made with [Cursor](https://cursor.com)