### PR TITLE
fix: do not open RPC, WebSocket, or gRPC in ufw

### DIFF
--- a/2-install-jito-validator.sh
+++ b/2-install-jito-validator.sh
@@ -149,6 +149,7 @@ if [[ "$LANG_SCRIPT" == "zh" ]]; then
   M_VERSION="版本: %s"
   M_STEP8="生成 Validator Keypair..."
   M_STEP9="配置防火墙..."
+  M_FW_PUBLIC_CLOSED="8899/8900/10900 不对公网开放，仅本机可访问"
   M_STEP10="复制 validator 配置文件..."
   M_TIER="检测到 %sGB RAM - 将使用 TIER %s 配置"
   M_STEP11="配置 systemd 服务..."
@@ -205,6 +206,7 @@ else
   M_VERSION="Version: %s"
   M_STEP8="Generate Validator Keypair..."
   M_STEP9="Configure firewall..."
+  M_FW_PUBLIC_CLOSED="8899/8900/10900 are not open to the public; localhost only"
   M_STEP10="Copy validator configs..."
   M_TIER="%sGB RAM detected - using TIER %s config"
   M_STEP11="Configure systemd service..."
@@ -424,9 +426,14 @@ ufw --force enable
 ufw allow 22
 ufw allow "$VALIDATOR_UFW_PORT_RANGE"/tcp
 ufw allow "$VALIDATOR_UFW_PORT_RANGE"/udp
-ufw allow 8899   # HTTP
-ufw allow 8900   # WS
-ufw allow 10900  # GRPC
+# RPC / WebSocket / Yellowstone gRPC stay localhost-only. Public scanners
+# hitting 8899/8900/10900 overload the node; allow a specific client IP later
+# if remote access is required.
+for port in 8899 8900 10900; do
+  yes | ufw delete allow "$port" >/dev/null 2>&1 || true
+  yes | ufw delete allow "$port/tcp" >/dev/null 2>&1 || true
+done
+echo "   ✓ $M_FW_PUBLIC_CLOSED"
 ufw status || true
 
 echo ""

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ After completing your RPC node installation, you can enhance performance with Ji
 - **Repository**: [jito-shredstream-install](https://github.com/0xfnzero/jito-shredstream-install)
 
 ShredStream provides low-latency block streaming for Jito MEV infrastructure.
+This RPC installer does not open ShredStream proxy ports. Keep those ports
+firewalled in the ShredStream install unless a specific client IP needs access.
 
 ## 📊 Monitoring & Management
 
@@ -318,26 +320,24 @@ fully compatible.
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
-| **8899** | HTTP | RPC endpoint |
-| **8900** | WebSocket | Real-time subscriptions |
-| **10900** | gRPC | High-performance data streaming; open by default for compatibility |
-| **8000-8030** | TCP/UDP | Validator communication (dynamic) |
+| **8899** | HTTP | RPC endpoint (localhost only by default) |
+| **8900** | WebSocket | Real-time subscriptions (localhost only by default) |
+| **10900** | gRPC | Yellowstone gRPC (localhost only by default) |
+| **8000-8030** | TCP/UDP | Validator gossip / shreds (must stay public) |
 
-The installer does not require a gRPC token, so existing clients continue to
-work without additional metadata. Operators with a fixed client IP can
-optionally restrict port 10900:
+The installer enables ufw and opens SSH plus the validator dynamic port range.
+It does **not** open 8899, 8900, or 10900 to the internet. Local tools such as
+`curl http://127.0.0.1:8899` keep working. Re-running `update-runtime.sh`
+removes any previous public allows for those three ports.
+
+To expose RPC, WebSocket, or gRPC to a fixed client IP:
 
 ```bash
-ufw delete allow 10900
+ufw allow from CLIENT_PUBLIC_IP to any port 8899 proto tcp
+ufw allow from CLIENT_PUBLIC_IP to any port 8900 proto tcp
 ufw allow from CLIENT_PUBLIC_IP to any port 10900 proto tcp
-ufw deny 10900/tcp
 ufw status numbered
 ```
-
-An IP allowlist is simple for fixed servers but must be updated whenever the
-client's public IP changes. Token authentication is more flexible for roaming
-clients, but every client must be configured to send the token, so it is not
-enabled automatically.
 
 ## 📈 Performance Metrics
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -170,6 +170,8 @@ bash /root/performance-monitor.sh snapshot
 - **项目仓库**: [jito-shredstream-install](https://github.com/0xfnzero/jito-shredstream-install)
 
 ShredStream 为 Jito MEV 基础设施提供低延迟的区块流传输。
+本 RPC 安装器不会开放 ShredStream 代理端口；请在 ShredStream 安装里自行限制
+防火墙，除非需要给指定客户端 IP 放行。
 
 ## 📊 监控与管理
 
@@ -305,22 +307,23 @@ sudo bash update-runtime.sh --restart
 
 | 端口 | 协议 | 用途 |
 |------|------|------|
-| **8899** | HTTP | RPC 端点 |
-| **8900** | WebSocket | 实时订阅 |
-| **10900** | gRPC | 高性能数据流；为兼容现有客户端默认开放 |
-| **8000-8030** | TCP/UDP | 验证者通信 (动态) |
+| **8899** | HTTP | RPC 端点（默认仅本机） |
+| **8900** | WebSocket | 实时订阅（默认仅本机） |
+| **10900** | gRPC | Yellowstone gRPC（默认仅本机） |
+| **8000-8030** | TCP/UDP | 验证者 gossip / shred（必须对公网开放） |
 
-安装器不会强制 gRPC token，现有客户端无需增加 metadata。固定出口 IP 的用户可选：
+安装器会启用 ufw，并放行 SSH 以及 validator 动态端口。**不会**把 8899、8900、
+10900 对公网开放。本机 `curl http://127.0.0.1:8899` 仍可用。再次执行
+`update-runtime.sh` 会删掉这三端口上已有的公网 allow 规则。
+
+如需给固定客户端 IP 开放 RPC、WebSocket 或 gRPC：
 
 ```bash
-ufw delete allow 10900
+ufw allow from 客户端公网IP to any port 8899 proto tcp
+ufw allow from 客户端公网IP to any port 8900 proto tcp
 ufw allow from 客户端公网IP to any port 10900 proto tcp
-ufw deny 10900/tcp
 ufw status numbered
 ```
-
-IP 白名单配置简单，但客户端公网 IP 变化后必须同步修改。Token 更适合 IP 经常变化的
-客户端，但每个客户端都必须携带 token，因此本项目不默认启用。
 
 ## 📈 性能指标
 

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -133,6 +133,14 @@ install -m 0644 "$logrotate_tmp" /etc/logrotate.d/solana-rpc
 
 systemctl daemon-reload
 
+if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -qi '^Status: active'; then
+  for port in 8899 8900 10900; do
+    yes | ufw delete allow "$port" >/dev/null 2>&1 || true
+    yes | ufw delete allow "$port/tcp" >/dev/null 2>&1 || true
+  done
+  echo "Public ufw allows for 8899/8900/10900 were removed; RPC, WebSocket, and gRPC stay localhost-only."
+fi
+
 echo "Runtime configuration updated without deleting ledger, accounts, or snapshots."
 echo "Previous configuration backup: $backup_dir"
 


### PR DESCRIPTION
## Summary
- New installs no longer `ufw allow` 8899 (RPC), 8900 (WebSocket), or 10900 (Yellowstone gRPC).
- `update-runtime.sh` deletes those public allows on existing nodes so scanners stop hitting the RPC.
- Validator gossip `8000-8030` stays open. Localhost `curl` to 8899 still works.
- Docs show how to allow a specific client IP when remote access is required.

## Test plan
- [ ] Fresh install: `ufw status` shows 22 and 8000:8030 only, not 8899/8900/10900
- [ ] Existing node: `sudo bash update-runtime.sh` then confirm those three allows are gone
- [ ] `curl http://127.0.0.1:8899` still works
- [ ] External scan of 8899/8900/10900 is blocked


Made with [Cursor](https://cursor.com)