### PR TITLE
fix: explicitly deny public RPC, WebSocket, and gRPC ports

### DIFF
--- a/2-install-jito-validator.sh
+++ b/2-install-jito-validator.sh
@@ -16,6 +16,9 @@ LANG_CACHE_FILE="$SCRIPT_DIR/solana-rpc-lang"
 # shellcheck source=lang.sh
 source "$SCRIPT_DIR/lang.sh"
 
+# shellcheck source=ufw-close-public-api.sh
+source "$SCRIPT_DIR/ufw-close-public-api.sh"
+
 BASE=${BASE:-/root/sol}
 BIN="$BASE/bin"
 KEYPAIR="$BIN/validator-keypair.json"
@@ -149,7 +152,7 @@ if [[ "$LANG_SCRIPT" == "zh" ]]; then
   M_VERSION="版本: %s"
   M_STEP8="生成 Validator Keypair..."
   M_STEP9="配置防火墙..."
-  M_FW_PUBLIC_CLOSED="8899/8900/10900 不对公网开放，仅本机可访问"
+  M_FW_PUBLIC_CLOSED="已关闭 8899/8900/10900 公网访问，仅本机可连"
   M_STEP10="复制 validator 配置文件..."
   M_TIER="检测到 %sGB RAM - 将使用 TIER %s 配置"
   M_STEP11="配置 systemd 服务..."
@@ -206,7 +209,7 @@ else
   M_VERSION="Version: %s"
   M_STEP8="Generate Validator Keypair..."
   M_STEP9="Configure firewall..."
-  M_FW_PUBLIC_CLOSED="8899/8900/10900 are not open to the public; localhost only"
+  M_FW_PUBLIC_CLOSED="Closed public access to 8899/8900/10900; localhost only"
   M_STEP10="Copy validator configs..."
   M_TIER="%sGB RAM detected - using TIER %s config"
   M_STEP11="Configure systemd service..."
@@ -426,13 +429,8 @@ ufw --force enable
 ufw allow 22
 ufw allow "$VALIDATOR_UFW_PORT_RANGE"/tcp
 ufw allow "$VALIDATOR_UFW_PORT_RANGE"/udp
-# RPC / WebSocket / Yellowstone gRPC stay localhost-only. Public scanners
-# hitting 8899/8900/10900 overload the node; allow a specific client IP later
-# if remote access is required.
-for port in 8899 8900 10900; do
-  yes | ufw delete allow "$port" >/dev/null 2>&1 || true
-  yes | ufw delete allow "$port/tcp" >/dev/null 2>&1 || true
-done
+# Drop any existing public allows, then deny RPC / WebSocket / gRPC.
+close_ufw_public_api_ports
 echo "   ✓ $M_FW_PUBLIC_CLOSED"
 ufw status || true
 

--- a/README.md
+++ b/README.md
@@ -325,17 +325,19 @@ fully compatible.
 | **10900** | gRPC | Yellowstone gRPC (localhost only by default) |
 | **8000-8030** | TCP/UDP | Validator gossip / shreds (must stay public) |
 
-The installer enables ufw and opens SSH plus the validator dynamic port range.
-It does **not** open 8899, 8900, or 10900 to the internet. Local tools such as
-`curl http://127.0.0.1:8899` keep working. Re-running `update-runtime.sh`
-removes any previous public allows for those three ports.
+The installer enables ufw, opens SSH plus the validator dynamic port range, then
+**closes** 8899, 8900, and 10900: it deletes any existing allows (including
+previous public opens) and adds `ufw deny` for those TCP ports. Localhost
+`curl http://127.0.0.1:8899` still works. Re-running `update-runtime.sh`
+applies the same close on nodes that already opened these ports.
 
-To expose RPC, WebSocket, or gRPC to a fixed client IP:
+To expose RPC, WebSocket, or gRPC to a fixed client IP, insert the allow
+**before** the deny rule:
 
 ```bash
-ufw allow from CLIENT_PUBLIC_IP to any port 8899 proto tcp
-ufw allow from CLIENT_PUBLIC_IP to any port 8900 proto tcp
-ufw allow from CLIENT_PUBLIC_IP to any port 10900 proto tcp
+ufw insert 1 allow from CLIENT_PUBLIC_IP to any port 8899 proto tcp
+ufw insert 1 allow from CLIENT_PUBLIC_IP to any port 8900 proto tcp
+ufw insert 1 allow from CLIENT_PUBLIC_IP to any port 10900 proto tcp
 ufw status numbered
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -312,16 +312,17 @@ sudo bash update-runtime.sh --restart
 | **10900** | gRPC | Yellowstone gRPC（默认仅本机） |
 | **8000-8030** | TCP/UDP | 验证者 gossip / shred（必须对公网开放） |
 
-安装器会启用 ufw，并放行 SSH 以及 validator 动态端口。**不会**把 8899、8900、
-10900 对公网开放。本机 `curl http://127.0.0.1:8899` 仍可用。再次执行
-`update-runtime.sh` 会删掉这三端口上已有的公网 allow 规则。
+安装器会启用 ufw，放行 SSH 和 validator 动态端口，然后**关闭** 8899、8900、
+10900：删除这些端口上已有的 allow（包括以前开过的公网规则），并加上
+`ufw deny`。本机 `curl http://127.0.0.1:8899` 仍可用。已开放过的节点再跑
+`update-runtime.sh` 也会被关掉。
 
-如需给固定客户端 IP 开放 RPC、WebSocket 或 gRPC：
+如需给固定客户端 IP 开放，必须把 allow **插到 deny 前面**：
 
 ```bash
-ufw allow from 客户端公网IP to any port 8899 proto tcp
-ufw allow from 客户端公网IP to any port 8900 proto tcp
-ufw allow from 客户端公网IP to any port 10900 proto tcp
+ufw insert 1 allow from 客户端公网IP to any port 8899 proto tcp
+ufw insert 1 allow from 客户端公网IP to any port 8900 proto tcp
+ufw insert 1 allow from 客户端公网IP to any port 10900 proto tcp
 ufw status numbered
 ```
 

--- a/ufw-close-public-api.sh
+++ b/ufw-close-public-api.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Close public access to RPC, WebSocket, and Yellowstone gRPC.
+# Deletes every matching ufw rule (including previous allows) then denies the ports.
+# Loopback is not filtered by these rules, so localhost RPC still works.
+
+close_ufw_public_api_ports() {
+  local port rule_num i status_out
+
+  if ! command -v ufw >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for port in 8899 8900 10900; do
+    i=0
+    while ((i < 50)); do
+      status_out=$(LC_ALL=C ufw status numbered 2>/dev/null || true)
+      rule_num=$(awk -v p="$port" '
+        {
+          if ($0 !~ /^\[/) next
+          line = $0
+          sub(/^\[ */, "", line)
+          sub(/\].*/, "", line)
+          if (line !~ /^[0-9]+$/) next
+          if ($0 ~ "(^|[^0-9])" p "([^0-9]|$)") {
+            print line
+            exit
+          }
+        }
+      ' <<<"$status_out")
+      [[ -n "$rule_num" ]] || break
+      yes | ufw delete "$rule_num" >/dev/null 2>&1 || break
+      i=$((i + 1))
+    done
+    ufw deny "$port"/tcp >/dev/null 2>&1 || true
+  done
+}

--- a/update-runtime.sh
+++ b/update-runtime.sh
@@ -7,6 +7,9 @@ SERVICE_NAME=${SERVICE_NAME:-sol}
 RESTART=false
 BACKUP_ROOT=${BACKUP_ROOT:-/root/sol/runtime-backups}
 
+# shellcheck source=ufw-close-public-api.sh
+source "$SCRIPT_DIR/ufw-close-public-api.sh"
+
 if [[ ${1:-} == "--restart" ]]; then
   RESTART=true
 elif [[ $# -gt 0 ]]; then
@@ -34,6 +37,7 @@ required_files=(
   performance-monitor.sh
   logrotate-solana-rpc
   sol.service
+  ufw-close-public-api.sh
 )
 
 for file in "${required_files[@]}"; do
@@ -133,12 +137,9 @@ install -m 0644 "$logrotate_tmp" /etc/logrotate.d/solana-rpc
 
 systemctl daemon-reload
 
-if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -qi '^Status: active'; then
-  for port in 8899 8900 10900; do
-    yes | ufw delete allow "$port" >/dev/null 2>&1 || true
-    yes | ufw delete allow "$port/tcp" >/dev/null 2>&1 || true
-  done
-  echo "Public ufw allows for 8899/8900/10900 were removed; RPC, WebSocket, and gRPC stay localhost-only."
+if command -v ufw >/dev/null 2>&1; then
+  close_ufw_public_api_ports
+  echo "Closed public ufw access to 8899/8900/10900 (RPC, WebSocket, gRPC)."
 fi
 
 echo "Runtime configuration updated without deleting ledger, accounts, or snapshots."


### PR DESCRIPTION
## Summary
- Do not merely skip opening 8899/8900/10900: delete every existing ufw rule for those ports (including previous public allows) and add `ufw deny`.
- `update-runtime.sh` applies the same close on nodes that already opened the ports.
- Localhost RPC remains available. Docs show inserting a client-IP allow before the deny rule.

## Test plan
- [ ] Node with `ufw allow 8899`: run `sudo bash update-runtime.sh`, then `ufw status` shows DENY for 8899/8900/10900
- [ ] External access to those ports is blocked
- [ ] `curl http://127.0.0.1:8899` still works


Made with [Cursor](https://cursor.com)